### PR TITLE
fix: Improve field type translation

### DIFF
--- a/ormdantic/generator/_table.py
+++ b/ormdantic/generator/_table.py
@@ -4,13 +4,11 @@ from datetime import date, datetime
 from types import UnionType
 from typing import Any, get_args, get_origin
 
-from ormdantic.handler import TableName_From_Model, TypeConversionError
-from ormdantic.models import Map, OrmTable
 from pydantic import BaseModel
 from pydantic.fields import ModelField
 from sqlalchemy import (
-    Boolean,
     JSON,
+    Boolean,
     Column,
     Date,
     DateTime,
@@ -24,6 +22,9 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncEngine
+
+from ormdantic.handler import TableName_From_Model, TypeConversionError
+from ormdantic.models import Map, OrmTable
 
 
 class PydanticSQLTableGenerator:


### PR DESCRIPTION
Every subclass of the listed basic types is assumed to be meant to be translated to the corresponding SQLAlchemy types.  Adds support for the Boolean, Date and DateTime types, fixes an issue where e.g. ConstrainedInt would be translated to JSON type, see #43 .

Since this changes the database type for some python types, it might break code or lead to unexpected results when regenerating tables that were first created before this change.