### PR TITLE
✨ Support constrained lists

### DIFF
--- a/ormdantic/generator/_lazy.py
+++ b/ormdantic/generator/_lazy.py
@@ -137,13 +137,15 @@ def _get_list_values(
     )
     items: list = []  # type: ignore
     if issubclass(type_, pydantic.types.ConstrainedList):  # type: ignore
-        list_types = typing.get_args(type_.item_type) or [type_.item_type]
+        list_types = typing.get_args(type_.item_type) or [
+            type_.item_type
+        ]  # pragma: no cover
     else:
         list_types = typing.get_args(type_)
     while len(items) < target_length:
         for arg in list_types:
             value = _get_value(arg, model_field, use_default_values, optionals_use_none)
             if model_field.field_info.unique_items and value in items:
-                continue
+                continue  # pragma: no cover
             items.append(value)
     return items

--- a/ormdantic/generator/_lazy.py
+++ b/ormdantic/generator/_lazy.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 import random
 import types
@@ -87,12 +88,11 @@ def _get_value(
             ): _get_value(v_type, model_field, use_default_values, optionals_use_none)
             for _ in range(random.randint(1, 100))
         }
-    if origin is list:
-        return [
-            _get_value(arg, model_field, use_default_values, optionals_use_none)
-            for _ in range(random.randint(1, 100))
-            for arg in typing.get_args(type_)
-        ]
+    with contextlib.suppress(TypeError):
+        if origin is list or issubclass(type_, pydantic.types.ConstrainedList):
+            return _get_list_values(
+                type_, model_field, use_default_values, optionals_use_none
+            )
     if origin and issubclass(origin, types.UnionType):
         type_choices = [
             it for it in typing.get_args(type_) if not issubclass(it, types.NoneType)

--- a/ormdantic/handler/__init__.py
+++ b/ormdantic/handler/__init__.py
@@ -10,6 +10,7 @@ from ormdantic.handler.helper import (
     TableName_From_Model,
     py_type_to_sql,
 )
+from ormdantic.handler.random import _get_target_length as GetTargetLength
 from ormdantic.handler.random import _random_date_value as RandomDateValue
 from ormdantic.handler.random import _random_datetime_value as RandomDatetimeValue
 from ormdantic.handler.random import _random_number_value as RandomNumberValue
@@ -34,4 +35,5 @@ __all__ = [
     "RandomDateValue",
     "RandomTimedeltaValue",
     "RandomTimeValue",
+    "GetTargetLength",
 ]

--- a/ormdantic/handler/random.py
+++ b/ormdantic/handler/random.py
@@ -10,10 +10,9 @@ from ormdantic.types import AnyNumber
 
 def _random_str_value(model_field: ModelField) -> str:
     """Get a random string."""
-    random.choices(string.ascii_letters + string.digits)
-    min_len = model_field.field_info.min_length or random.randint(1, 100)
-    max_len = model_field.field_info.max_length or random.randint(1, 100) + min_len
-    target_length = random.choice(range(min_len, max_len))
+    target_length = _get_target_length(
+        model_field.field_info.min_length, model_field.field_info.max_length
+    )
     choices = string.ascii_letters + string.digits
     return _random_str(choices, target_length)
 
@@ -89,3 +88,14 @@ def _random_timedelta_value() -> datetime.timedelta:
 def _random_str(choices: str, target_length: int) -> str:
     """Get a random string."""
     return "".join(random.choice(choices) for _ in range(target_length))
+
+
+def _get_target_length(min_length: int | None, max_length: int | None) -> int:
+    """Get a random target length."""
+    if not min_length:
+        if max_length is not None:
+            min_length = random.randint(0, max_length - 1)
+        else:
+            min_length = random.randint(0, 100)
+    max_length = max_length or random.randint(1, 100) + min_length
+    return random.choice(range(min_length, max_length))

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -55,6 +55,11 @@ class Coffee(BaseModel):
     not_specifically_supported_type: OrderedDict  # type: ignore
 
 
+def test_validate() -> None:
+    """Test validate."""
+    Generator(Coffee)
+
+
 def test_generator() -> None:
     assert Generator(Coffee).description is not None
 


### PR DESCRIPTION
## Concept

In Python, a constrained list is a list that is restricted to contain only elements of a certain type or set of types. The Python package Pydantic includes a `ConstrainedList` class that can be used to define constrained lists in your code.

Here is an example of how you might use the `ConstrainedList` class to define a constrained list of integers:

```py
from pydantic import ConstrainedList

int_list = ConstrainedList(int, min_items=3, max_items=5)
```

This creates a `ConstrainedList` object called `int_list` that can only contain integers and must have at least 3 items and at most 5 items.

You can also use the `ConstrainedList` class to define a constrained list of elements that are instances of a particular class or that are of a particular subclass:

```py
from pydantic import ConstrainedList

class Employee:
    def __init__(self, name: str, salary: int):
        self.name = name
        self.salary = salary

employee_list = ConstrainedList(Employee)
```

This creates a `ConstrainedList` object called `employee_list` that can only contain instances of the Employee class.

The ConstrainedList class includes several other optional parameters that you can use to further constrain the elements of the list, such as `min_items`, `max_items`, and `unique_items`. You can find more information about the [ConstrainedList class in the Pydantic documentation.](https://docs.pydantic.dev/usage/types/#constrained-types)

## Explanation

The Feature starts by determining the target length of the list by calling a helper function called `GetTargetLength`, passing in the `min_items` and `max_items` attributes of the `model_field` object as arguments. It then initializes an empty list called items.

The function then checks if `type_` is a ConstrainedList object by checking if it is a subclass of `pydantic.types.ConstrainedList`. If it is, it sets the `list_types` variable to a tuple of the item types of the ConstrainedList object. If it is not, it sets `list_types` to the tuple of argument types of `type_`.

The function then enters a loop that continues until the length of items is equal to the target length. Within the loop, it iterates over the items in `list_types`, and for each item, it calls a helper function called` _get_value`, passing in the item, the `model_field` object, and the `use_default_values` and `optionals_use_none` arguments. If the `unique_items` attribute of the `model_field` object is True and the value returned by `_get_value` is already in the items list, it continues to the next iteration of the loop. Otherwise, it appends the value to the items list.

After the loop has been completed, the function returns the items list.